### PR TITLE
Enhanced plugin to work after (along) a postcss-svg run

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import SVGO from 'svgo';
 import postcss from 'postcss';
 import isSvg from 'is-svg';
 
-const dataURI = /data:image\/svg\+xml;(charset=)?utf-8,/;
+const dataURI = /data:image\/svg\+xml(;charset=utf-8)?,/;
 
 function minifyPromise (svgo, decl) {
     return new Promise((resolve, reject) => {
@@ -18,11 +18,11 @@ function minifyPromise (svgo, decl) {
                 if (result.error) {
                     return reject(`Error parsing SVG: ${result.error}`);
                 }
-                let o = `url(${quote}data:image/svg+xml;utf-8,${result.data}${quote})`;
+                let o = `url(${quote}data:image/svg+xml;utf-8,${encodeURIComponent(result.data)}${quote})`;
                 return cb(null, o);
             });
         };
-        replace(decl.value, /url\(("|')?(.*)\1\)/g, minify, (err, result) => {
+        replace(decodeURIComponent(decl.value), /url\(("|')?(.*)\1\)/g, minify, (err, result) => {
             decl.value = result;
             resolve();
         });


### PR DESCRIPTION
postcss-svgo was not able to discover and optimize svg-data-uris processed by postcss-svg.
The latter generates inline SVGs that have no charset defined and are uri-encoded.

With these changes postcss-svg and postcss-svgo run smoothly together :-)