### PR TITLE
Adding support for uri-encoded inline SVGs with- and without charset-definitions

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -13,6 +13,18 @@ let tests = [{
     fixture: 'h1{background:url(\'data:image/svg+xml;utf-8,<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"><circle cx="50" cy="50" r="40" fill="yellow" /><!--test comment--></svg>\')}',
     expected: 'h1{background:url(\'data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="40" fill="#ff0"/></svg>\')}',
 }, {
+    message: 'should optimise inline svg with standard charset definition',
+    fixture: 'h1{background:url(\'data:image/svg+xml;charset=utf-8,<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"><circle cx="50" cy="50" r="40" fill="yellow" /><!--test comment--></svg>\')}',
+    expected: 'h1{background:url(\'data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="40" fill="#ff0"/></svg>\')}',
+}, {
+    message: 'should optimise inline svg without charset definition',
+    fixture: 'h1{background:url(\'data:image/svg+xml,<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"><circle cx="50" cy="50" r="40" fill="yellow" /><!--test comment--></svg>\')}',
+    expected: 'h1{background:url(\'data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="40" fill="#ff0"/></svg>\')}',
+}, {
+    message: 'should optimise uri-encoded inline svg',
+    fixture: 'h1{background:url(\'data:image/svg+xml;utf-8,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22utf-8%22%3F%3E%3C!DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20xml%3Aspace%3D%22preserve%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2240%22%20fill%3D%22yellow%22%20%2F%3E%3C!--test%20comment--%3E%3C%2Fsvg%3E\')}',
+    expected: 'h1{background:url(\'data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2240%22%20fill%3D%22%23ff0%22%2F%3E%3C%2Fsvg%3E\')}',
+}, {
     message: 'should allow users to customise the output',
     fixture: 'h1{background:url(\'data:image/svg+xml;utf-8,<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"><circle cx="50" cy="50" r="40" fill="yellow" /><!--test comment--></svg>\')}',
     expected: 'h1{background:url(\'data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="40" fill="#ff0"/><!--test comment--></svg>\')}',

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,13 @@ import SVGO from 'svgo';
 import postcss from 'postcss';
 import isSvg from 'is-svg';
 
-const dataURI = /data:image\/svg\+xml;(charset=)?utf-8,/;
+const dataURI = /data:image\/svg\+xml(;(charset=)?utf-8)?,/;
+let encode = encodeURIComponent;
+let decode = decodeURIComponent;
 
 function minifyPromise (svgo, decl) {
     return new Promise((resolve, reject) => {
+        let isUriEncoded = decode(decl.value) !== decl.value;
         let minify = (_, quote, svg, offset, str, cb) => {
             if (!dataURI.test(svg) || !isSvg(svg)) {
                 return cb(null, str);
@@ -18,11 +21,13 @@ function minifyPromise (svgo, decl) {
                 if (result.error) {
                     return reject(`Error parsing SVG: ${result.error}`);
                 }
-                let o = `url(${quote}data:image/svg+xml;utf-8,${result.data}${quote})`;
+                let data = isUriEncoded ? encode(result.data) : result.data;
+                let o = `url(${quote}data:image/svg+xml;utf-8,${data}${quote})`;
                 return cb(null, o);
             });
         };
-        replace(decl.value, /url\(("|')?(.*)\1\)/g, minify, (err, result) => {
+        replace(isUriEncoded ? decode(decl.value) : decl.value,
+            /url\(("|')?(.*)\1\)/g, minify, (err, result) => {
             decl.value = result;
             resolve();
         });


### PR DESCRIPTION
This one replaces my previous PR. Now only uri-encoded SVGs are decoded and encoded again.

+ Added three additional tests.